### PR TITLE
Tv/telecommands config storage

### DIFF
--- a/cts2_obc_firmware/src/error.rs
+++ b/cts2_obc_firmware/src/error.rs
@@ -1,4 +1,4 @@
-use cts2_obc_telecommands::error::ParsedTelecommandErr;
+use cts2_obc_telecommands::error::{ConfigError, ParsedTelecommandErr};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,4 +11,7 @@ pub enum DispatchCommandErr {
 }
 
 #[derive(Debug, Error)]
-pub enum ExecuteCommandErr {}
+pub enum ExecuteCommandErr {
+    #[error("Config operation error")]
+    ConfigError(#[from] ConfigError),
+}

--- a/cts2_obc_firmware/src/telecommand_implementation.rs
+++ b/cts2_obc_firmware/src/telecommand_implementation.rs
@@ -3,7 +3,7 @@ use core::fmt::Write;
 use crate::error::ExecuteCommandErr;
 use crate::timekeeping::uptime_ms;
 use crate::umbilical_uart::send_umbilical_uart;
-use cts2_obc_telecommands::config::{ConfigVariableName, ConfigValue};
+use cts2_obc_telecommands::config::{ConfigValue, ConfigVariableName};
 use cts2_obc_telecommands::get_config_store;
 
 pub mod demo_commands;
@@ -17,7 +17,7 @@ pub fn get_sys_uptime_ms_telecommand() -> Result<(), ExecuteCommandErr> {
     Ok(())
 }
 
-pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), ExecuteCommandErr>{
+pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), ExecuteCommandErr> {
     let config_store = get_config_store();
     let value = config_store.get(name);
 
@@ -28,7 +28,10 @@ pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), Execut
     Ok(())
 }
 
-pub fn config_set_config_variable(name: ConfigVariableName, value: ConfigValue) -> Result<(), ExecuteCommandErr> {
+pub fn config_set_config_variable(
+    name: ConfigVariableName,
+    value: ConfigValue,
+) -> Result<(), ExecuteCommandErr> {
     let config_store = get_config_store();
     config_store.set(name, value)?;
 

--- a/cts2_obc_firmware/src/telecommand_implementation.rs
+++ b/cts2_obc_firmware/src/telecommand_implementation.rs
@@ -1,6 +1,11 @@
+use core::fmt::Write;
+
 use crate::error::ExecuteCommandErr;
 use crate::timekeeping::uptime_ms;
 use crate::umbilical_uart::send_umbilical_uart;
+use cts2_obc_telecommands::config::{ConfigVariableName, ConfigValue};
+use cts2_obc_telecommands::get_config_store;
+
 pub mod demo_commands;
 
 pub fn get_sys_uptime_ms_telecommand() -> Result<(), ExecuteCommandErr> {
@@ -12,10 +17,24 @@ pub fn get_sys_uptime_ms_telecommand() -> Result<(), ExecuteCommandErr> {
     Ok(())
 }
 
-pub fn config_get_config_variable(name: _) -> _ {
-    todo!()
+pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), ExecuteCommandErr>{
+    let config_store = get_config_store();
+    let value = config_store.get(name);
+
+    let mut buffer = heapless::String::<128>::new();
+    let _ = write!(buffer, "Variable: {:?} = {:?}\r\n", name, value);
+
+    send_umbilical_uart(buffer.as_bytes());
+    Ok(())
 }
 
-pub fn config_set_config_variable(name: _, value: _) -> _ {
-    todo!()
+pub fn config_set_config_variable(name: ConfigVariableName, value: ConfigValue) -> Result<(), ExecuteCommandErr> {
+    let config_store = get_config_store();
+    config_store.set(name, value)?;
+
+    let mut buffer = heapless::String::<128>::new();
+    let _ = write!(buffer, "Variable: {:?} set to {:?}\r\n", name, value);
+
+    send_umbilical_uart(buffer.as_bytes());
+    Ok(())
 }

--- a/cts2_obc_firmware/src/telecommand_implementation.rs
+++ b/cts2_obc_firmware/src/telecommand_implementation.rs
@@ -17,7 +17,7 @@ pub fn get_sys_uptime_ms_telecommand() -> Result<(), ExecuteCommandErr> {
     Ok(())
 }
 
-pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), ExecuteCommandErr> {
+pub fn get_config_variable(name: ConfigVariableName) -> Result<(), ExecuteCommandErr> {
     let config_store = get_config_store();
     let value = config_store.get(name);
 
@@ -28,7 +28,7 @@ pub fn config_get_config_variable(name: ConfigVariableName) -> Result<(), Execut
     Ok(())
 }
 
-pub fn config_set_config_variable(
+pub fn set_config_variable(
     name: ConfigVariableName,
     value: ConfigValue,
 ) -> Result<(), ExecuteCommandErr> {

--- a/cts2_obc_firmware/src/telecommand_implementation.rs
+++ b/cts2_obc_firmware/src/telecommand_implementation.rs
@@ -11,3 +11,11 @@ pub fn get_sys_uptime_ms_telecommand() -> Result<(), ExecuteCommandErr> {
     send_umbilical_uart(&buff);
     Ok(())
 }
+
+pub fn config_get_config_variable(name: _) -> _ {
+    todo!()
+}
+
+pub fn config_set_config_variable(name: _, value: _) -> _ {
+    todo!()
+}

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -1,4 +1,5 @@
 use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use core::fmt::Write;
 use cts2_obc_telecommands::error::ParsedTelecommandErr;
 use cts2_obc_telecommands::{Telecommand, parse_telecommand};
 use rtt_target::rprintln;
@@ -111,6 +112,17 @@ fn dispatch_command(cmd_str: &str) -> Result<(), DispatchCommandErr> {
                 }
                 ParsedTelecommandErr::DeserializationError(_) => {
                     send_umbilical_uart(b"ERR: failed to deserialize command arguments\r\n");
+                }
+                ParsedTelecommandErr::MissingArgument(idx) => {
+                    let mut msg = heapless::String::<64>::new();
+                    let _ = write!(msg, "ERR: missing required argument at index {}\r\n", idx);
+                    send_umbilical_uart(msg.as_bytes());
+                }
+                ParsedTelecommandErr::ExceededArgumentCount => {
+                    send_umbilical_uart(b"ERR: too many arguments provided\r\n");
+                }
+                ParsedTelecommandErr::ConfigError(_) => {
+                    send_umbilical_uart(b"ERR: configuration error\r\n");
                 }
             }
             return Err(e.into());

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -159,11 +159,11 @@ fn dispatch_command(cmd_str: &str) -> Result<(), DispatchCommandErr> {
         Telecommand::get_sys_uptime => {
             crate::telecommand_implementation::get_sys_uptime_ms_telecommand()?
         }
-        Telecommand::config_get(name) => {
-            crate::telecommand_implementation::config_get_config_variable(name)?
+        Telecommand::get_config(name) => {
+            crate::telecommand_implementation::get_config_variable(name)?
         }
-        Telecommand::config_set(name, value) => {
-            crate::telecommand_implementation::config_set_config_variable(name, value)?
+        Telecommand::set_config(name, value) => {
+            crate::telecommand_implementation::set_config_variable(name, value)?
         }
     };
 

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -1,5 +1,5 @@
-use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use core::fmt::Write;
+use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use cts2_obc_telecommands::error::ParsedTelecommandErr;
 use cts2_obc_telecommands::{Telecommand, parse_telecommand};
 use rtt_target::rprintln;

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write;
 use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
-use cts2_obc_telecommands::error::ParsedTelecommandErr;
+use cts2_obc_telecommands::error::{ConfigError, ParsedTelecommandErr};
 use cts2_obc_telecommands::{Telecommand, parse_telecommand};
 use rtt_target::rprintln;
 use stm32l4xx_hal::{self as stm32_hal};
@@ -121,8 +121,24 @@ fn dispatch_command(cmd_str: &str) -> Result<(), DispatchCommandErr> {
                 ParsedTelecommandErr::ExceededArgumentCount => {
                     send_umbilical_uart(b"ERR: too many arguments provided\r\n");
                 }
-                ParsedTelecommandErr::ConfigError(_) => {
+
+                // When the errors got bigger, consider move into another function
+                ParsedTelecommandErr::ConfigError(e_conf) => {
                     send_umbilical_uart(b"ERR: configuration error\r\n");
+                    match e_conf {
+                        ConfigError::ConfigVariableNotFound => {
+                            send_umbilical_uart(b"ERR: configuration variable not found\r\n");
+                        }
+                        ConfigError::ConfigVariableNotThisType => {
+                            send_umbilical_uart(b"ERR: configuration variable is not this type\r\n");
+                        }
+                        ConfigError::ConfigVariableUnknownType => {
+                            send_umbilical_uart(b"ERR: unknown type for configuration variable\r\n");
+                        }
+                        ConfigError::ConfigParseValueTypeError => {
+                            send_umbilical_uart(b"ERR: cannot parse the type with the value string\r\n");
+                        }
+                    }
                 }
             }
             return Err(e.into());

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -125,6 +125,12 @@ fn dispatch_command(cmd_str: &str) -> Result<(), DispatchCommandErr> {
         Telecommand::get_sys_uptime => {
             crate::telecommand_implementation::get_sys_uptime_ms_telecommand()?
         }
+        Telecommand::config_get(name) => {
+            crate::telecommand_implementation::config_get_config_variable(name)?
+        }
+        Telecommand::config_set(name, value) => {
+            crate::telecommand_implementation::config_set_config_variable(name, value)?
+        }
     };
 
     Ok(())

--- a/cts2_obc_firmware/src/umbilical_uart.rs
+++ b/cts2_obc_firmware/src/umbilical_uart.rs
@@ -130,13 +130,19 @@ fn dispatch_command(cmd_str: &str) -> Result<(), DispatchCommandErr> {
                             send_umbilical_uart(b"ERR: configuration variable not found\r\n");
                         }
                         ConfigError::ConfigVariableNotThisType => {
-                            send_umbilical_uart(b"ERR: configuration variable is not this type\r\n");
+                            send_umbilical_uart(
+                                b"ERR: configuration variable is not this type\r\n",
+                            );
                         }
                         ConfigError::ConfigVariableUnknownType => {
-                            send_umbilical_uart(b"ERR: unknown type for configuration variable\r\n");
+                            send_umbilical_uart(
+                                b"ERR: unknown type for configuration variable\r\n",
+                            );
                         }
                         ConfigError::ConfigParseValueTypeError => {
-                            send_umbilical_uart(b"ERR: cannot parse the type with the value string\r\n");
+                            send_umbilical_uart(
+                                b"ERR: cannot parse the type with the value string\r\n",
+                            );
                         }
                     }
                 }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -1,0 +1,24 @@
+/**
+ * - Enum of all configuration variable names.
+ * - Struct that we create a global static singleton that contains all variable names.
+ * - Create a getter and a setter telecommand (getter arg: name of variable, 
+ *   setter arg: name of variable, value)
+ * - Add configuration variable: heartbeat in ms (for testing to start)
+ * - Add configuration variable: config_demo_variable1
+ */
+
+#![cfg_attr(not(test), no_std)]
+
+#[cfg(test)]
+extern crate std;
+
+#[derive(Debug)]
+
+
+// Enum of all configuration variable names
+enum ConfigVariable {
+    CONFIG_int_demo_var1,
+    CONFIG_int_demo_var2,
+    TASK_heartbeat_ms,
+    // TODO: Add more configuration variables here
+}

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -1,13 +1,21 @@
 use crate::error::ConfigError;
 use core::str::FromStr;
 /**
- * - Enum of all configuration variable names.
- * - Struct that we create a global static singleton that contains all variable names.
- * - Create a getter and a setter telecommand (getter arg: name of variable,
- *   setter arg: name of variable, value)
- * - Add configuration variable: heartbeat in ms (for testing to start)
- * - Add configuration variable: config_demo_variable1
- */
+* - Enum of all configuration variable names.
+* - Struct that we create a global static singleton that contains all variable names.
+* - Create a getter and a setter telecommand (getter arg: name of variable,
+*   setter arg: name of variable, value)
+* - Add configuration variable: heartbeat in ms (for testing to start)
+* - Add configuration variable: config_demo_variable1
+*
+* HOW TO ADD A NEW CONFIGURATION VARIABLE:
+* 1. Add actual variable to ConfigStore struct
+* 2. Add default value to ConfigStore::new()
+* 3. Add an enum to ConfigVariableName enum
+* 4. Add a string version to match in ConfigVariableName::from_str()
+* 5. Add a match case to ConfigStore::get()
+* 6. Add a match case to ConfigStore::set()
+*/
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::shared;

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -1,14 +1,14 @@
+use crate::error::ConfigError;
+use core::str::FromStr;
 /**
  * - Enum of all configuration variable names.
  * - Struct that we create a global static singleton that contains all variable names.
- * - Create a getter and a setter telecommand (getter arg: name of variable, 
+ * - Create a getter and a setter telecommand (getter arg: name of variable,
  *   setter arg: name of variable, value)
  * - Add configuration variable: heartbeat in ms (for testing to start)
  * - Add configuration variable: config_demo_variable1
  */
 use core::sync::atomic::{AtomicU32, Ordering};
-use core::str::FromStr;
-use crate::error::ConfigError;
 
 use crate::shared;
 
@@ -51,7 +51,7 @@ impl FromStr for ConfigValue {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (value_type, value_str) = shared::extract_function_and_args(s);
-        
+
         macro_rules! parse_value {
             ($type:ty, $variant:path) => {
                 value_str
@@ -107,11 +107,5 @@ impl ConfigStore {
             }
             _ => Err(ConfigError::ConfigTypeMismatch),
         }
-    }
-}
-
-impl ConfigValue {
-    pub fn parse_from_str(s: &str) -> Result<Self, ConfigError> {
-        Err(ConfigError::ConfigValueParseError)
     }
 }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -1,21 +1,5 @@
 use crate::error::ConfigError;
 use core::str::FromStr;
-/**
-* - Enum of all configuration variable names.
-* - Struct that we create a global static singleton that contains all variable names.
-* - Create a getter and a setter telecommand (getter arg: name of variable,
-*   setter arg: name of variable, value)
-* - Add configuration variable: heartbeat in ms (for testing to start)
-* - Add configuration variable: config_demo_variable1
-*
-* HOW TO ADD A NEW CONFIGURATION VARIABLE:
-* 1. Add actual variable to ConfigStore struct
-* 2. Add default value to ConfigStore::new()
-* 3. Add an enum to ConfigVariableName enum
-* 4. Add a string version to match in ConfigVariableName::from_str()
-* 5. Add a match case to ConfigStore::get()
-* 6. Add a match case to ConfigStore::set()
-*/
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::shared;

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -7,17 +7,32 @@
  * - Add configuration variable: config_demo_variable1
  */
 use core::sync::atomic::{AtomicU32, Ordering};
-
-// config operation errors
-// TODO: Move this into error.rs file after error handling branch is merged
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfigError {
-}
+use core::str::FromStr;
+use crate::error::ConfigError;
 
 // Global configuration store
 pub struct ConfigStore {
     heartbeat_ms: AtomicU32,
     config_demo_variable1: AtomicU32,
+}
+
+// All configuration variable names
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigVariableName {
+    HeartbeatMs,
+    ConfigDemoVariable1,
+}
+
+impl FromStr for ConfigVariableName {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "heartbeat_ms" => Ok(ConfigVariableName::HeartbeatMs),
+            "config_demo_variable1" => Ok(ConfigVariableName::ConfigDemoVariable1),
+            _ => Err(ConfigError::ConfigVariableNotFound),
+        }
+    }
 }
 
 impl ConfigStore {
@@ -55,13 +70,6 @@ impl ConfigStore {
             }
         }
     }
-}
-
-// --- Configuration Store (snake_case for json) ---
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfigVariableName {
-    HeartbeatMs,
-    ConfigDemoVariable1,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -51,27 +51,22 @@ impl FromStr for ConfigValue {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (value_type, value_str) = shared::extract_function_and_args(s);
+        
+        macro_rules! parse_value {
+            ($type:ty, $variant:path) => {
+                value_str
+                    .parse::<$type>()
+                    .map($variant)
+                    .map_err(|_| ConfigError::ConfigTypeMismatch)
+            };
+        }
+
         match value_type {
-            "u32" => value_str
-                .parse::<u32>()
-                .map(ConfigValue::U32)
-                .map_err(|_| ConfigError::ConfigTypeMismatch),
-            "bool" => value_str
-                .parse::<bool>()
-                .map(ConfigValue::Bool)
-                .map_err(|_| ConfigError::ConfigTypeMismatch),
-            "f32" => value_str
-                .parse::<f32>()
-                .map(ConfigValue::F32)
-                .map_err(|_| ConfigError::ConfigTypeMismatch),
-            "i32" => value_str
-                .parse::<i32>()
-                .map(ConfigValue::I32)
-                .map_err(|_| ConfigError::ConfigTypeMismatch),
-            "u8" => value_str
-                .parse::<u8>()
-                .map(ConfigValue::U8)
-                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            "u32" => parse_value!(u32, ConfigValue::U32),
+            "bool" => parse_value!(bool, ConfigValue::Bool),
+            "f32" => parse_value!(f32, ConfigValue::F32),
+            "i32" => parse_value!(i32, ConfigValue::I32),
+            "u8" => parse_value!(u8, ConfigValue::U8),
             _ => Err(ConfigError::ConfigVariableUnknownType),
         }
     }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -10,6 +10,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use core::str::FromStr;
 use crate::error::ConfigError;
 
+use crate::shared;
+
 // Global configuration store
 pub struct ConfigStore {
     heartbeat_ms: AtomicU32,
@@ -31,6 +33,46 @@ impl FromStr for ConfigVariableName {
             "heartbeat_ms" => Ok(ConfigVariableName::HeartbeatMs),
             "config_demo_variable1" => Ok(ConfigVariableName::ConfigDemoVariable1),
             _ => Err(ConfigError::ConfigVariableNotFound),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ConfigValue {
+    U32(u32),
+    Bool(bool),
+    F32(f32),
+    I32(i32),
+    U8(u8),
+}
+
+impl FromStr for ConfigValue {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (value_type, value_str) = shared::extract_function_and_args(s);
+        match value_type {
+            "u32" => value_str
+                .parse::<u32>()
+                .map(ConfigValue::U32)
+                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            "bool" => value_str
+                .parse::<bool>()
+                .map(ConfigValue::Bool)
+                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            "f32" => value_str
+                .parse::<f32>()
+                .map(ConfigValue::F32)
+                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            "i32" => value_str
+                .parse::<i32>()
+                .map(ConfigValue::I32)
+                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            "u8" => value_str
+                .parse::<u8>()
+                .map(ConfigValue::U8)
+                .map_err(|_| ConfigError::ConfigTypeMismatch),
+            _ => Err(ConfigError::ConfigVariableUnknownType),
         }
     }
 }
@@ -68,12 +110,13 @@ impl ConfigStore {
                 self.config_demo_variable1.store(v, Ordering::Relaxed);
                 Ok(())
             }
+            _ => Err(ConfigError::ConfigTypeMismatch),
         }
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum ConfigValue {
-    U32(u32),
-    // TODO: Add more types as needed (e.g., U64, Bool, F32, F64, etc.)
+impl ConfigValue {
+    pub fn parse_from_str(s: &str) -> Result<Self, ConfigError> {
+        Err(ConfigError::ConfigValueParseError)
+    }
 }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -6,19 +6,66 @@
  * - Add configuration variable: heartbeat in ms (for testing to start)
  * - Add configuration variable: config_demo_variable1
  */
+use core::sync::atomic::{AtomicU32, Ordering};
 
-#![cfg_attr(not(test), no_std)]
+// config operation errors
+// TODO: Move this into error.rs file after error handling branch is merged
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigError {
+}
 
-#[cfg(test)]
-extern crate std;
+// Global configuration store
+pub struct ConfigStore {
+    heartbeat_ms: AtomicU32,
+    config_demo_variable1: AtomicU32,
+}
 
-#[derive(Debug)]
+impl ConfigStore {
+    // create new config store with default values
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            heartbeat_ms: AtomicU32::new(1000),
+            config_demo_variable1: AtomicU32::new(0),
+        }
+    }
 
+    // get a config value by name
+    pub fn get(&self, name: ConfigVariableName) -> ConfigValue {
+        match name {
+            ConfigVariableName::HeartbeatMs => {
+                ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed))
+            }
+            ConfigVariableName::ConfigDemoVariable1 => {
+                ConfigValue::U32(self.config_demo_variable1.load(Ordering::Relaxed))
+            }
+        }
+    }
 
-// Enum of all configuration variable names
-enum ConfigVariable {
-    CONFIG_int_demo_var1,
-    CONFIG_int_demo_var2,
-    TASK_heartbeat_ms,
-    // TODO: Add more configuration variables here
+    // set a configuration value by name
+    pub fn set(&self, name: ConfigVariableName, value: ConfigValue) -> Result<(), ConfigError> {
+        match (name, value) {
+            (ConfigVariableName::HeartbeatMs, ConfigValue::U32(v)) => {
+                self.heartbeat_ms.store(v, Ordering::Relaxed);
+                Ok(())
+            }
+            (ConfigVariableName::ConfigDemoVariable1, ConfigValue::U32(v)) => {
+                self.config_demo_variable1.store(v, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+    }
+}
+
+// --- Configuration Store (snake_case for json) ---
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigVariableName {
+    HeartbeatMs,
+    ConfigDemoVariable1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ConfigValue {
+    U32(u32),
+    // TODO: Add more types as needed (e.g., U64, Bool, F32, F64, etc.)
 }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -57,7 +57,7 @@ impl FromStr for ConfigValue {
                 value_str
                     .parse::<$type>()
                     .map($variant)
-                    .map_err(|_| ConfigError::ConfigTypeMismatch)
+                    .map_err(|_| ConfigError::ConfigParseValueTypeError)
             };
         }
 
@@ -105,7 +105,7 @@ impl ConfigStore {
                 self.config_demo_variable1.store(v, Ordering::Relaxed);
                 Ok(())
             }
-            _ => Err(ConfigError::ConfigTypeMismatch),
+            _ => Err(ConfigError::ConfigVariableNotThisType),
         }
     }
 }

--- a/cts2_obc_telecommands/src/config.rs
+++ b/cts2_obc_telecommands/src/config.rs
@@ -13,6 +13,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use crate::shared;
 
 // Global configuration store
+// There is no float for atomic, consider
+// using AtomicU32 to store and just parse as float
 pub struct ConfigStore {
     heartbeat_ms: AtomicU32,
     config_demo_variable1: AtomicU32,
@@ -78,7 +80,7 @@ impl ConfigStore {
     pub const fn new() -> Self {
         Self {
             heartbeat_ms: AtomicU32::new(1000),
-            config_demo_variable1: AtomicU32::new(0),
+            config_demo_variable1: AtomicU32::new(123),
         }
     }
 

--- a/cts2_obc_telecommands/src/error.rs
+++ b/cts2_obc_telecommands/src/error.rs
@@ -8,3 +8,10 @@ pub enum ParsedTelecommandErr {
     #[error("Failed to deserialize telecommand arguments")]
     DeserializationError(#[from] serde_json_core::de::Error),
 }
+
+// config operation errors
+#[derive(Debug, PartialEq, Error)]
+pub enum ConfigError {
+    #[error("Configuration variable not found")]
+    ConfigVariableNotFound,
+}

--- a/cts2_obc_telecommands/src/error.rs
+++ b/cts2_obc_telecommands/src/error.rs
@@ -25,4 +25,13 @@ pub enum ParsedTelecommandErr {
 pub enum ConfigError {
     #[error("Configuration variable not found")]
     ConfigVariableNotFound,
+
+    #[error("Cannot parse value for configuration variable")]
+    ConfigValueParseError,
+
+    #[error("Type mismatch (cannot parse) for configuration variable")]
+    ConfigTypeMismatch,
+
+    #[error("Unknown type for configuration variable")]
+    ConfigVariableUnknownType,
 }

--- a/cts2_obc_telecommands/src/error.rs
+++ b/cts2_obc_telecommands/src/error.rs
@@ -21,16 +21,16 @@ pub enum ParsedTelecommandErr {
 }
 
 // config operation errors
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Copy, Clone, Error)]
 pub enum ConfigError {
     #[error("Configuration variable not found")]
     ConfigVariableNotFound,
 
-    #[error("Cannot parse value for configuration variable")]
-    ConfigValueParseError,
+    #[error("Cannot parse the type with the value string")]
+    ConfigParseValueTypeError,
 
-    #[error("Type mismatch (cannot parse) for configuration variable")]
-    ConfigTypeMismatch,
+    #[error("Type mismatch for configuration variable (config variable is another type)")]
+    ConfigVariableNotThisType,
 
     #[error("Unknown type for configuration variable")]
     ConfigVariableUnknownType,

--- a/cts2_obc_telecommands/src/error.rs
+++ b/cts2_obc_telecommands/src/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+pub type IndexMissing = u8;
+
 #[derive(Debug, Error, PartialEq)]
 pub enum ParsedTelecommandErr {
     #[error("Unknown telecommand")]
@@ -7,6 +9,15 @@ pub enum ParsedTelecommandErr {
 
     #[error("Failed to deserialize telecommand arguments")]
     DeserializationError(#[from] serde_json_core::de::Error),
+
+    #[error("Missing required argument")]
+    MissingArgument(IndexMissing),
+
+    #[error("Too many arguments provided")]
+    ExceededArgumentCount,
+
+    #[error("Configuration error")]
+    ConfigError(#[from] ConfigError),
 }
 
 // config operation errors

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -142,6 +142,36 @@ mod tests {
     }
 
     #[test]
+    fn test_config_store_set_type_mismatch() {
+        let store = ConfigStore::new();
+
+        let result = store.set(
+            ConfigVariableName::ConfigDemoVariable1,
+            ConfigValue::F32(42.0),
+        );
+
+        assert_eq!(result, Err(ConfigError::ConfigVariableNotThisType));
+    }
+
+    #[test]
+    fn test_config_store_parse_unknown_variable() {
+        let result = ConfigVariableName::from_str("unknown_variable");
+        assert_eq!(result, Err(ConfigError::ConfigVariableNotFound));
+    }
+
+    #[test]
+    fn test_config_store_parse_unknown_type() {
+        let result = ConfigValue::from_str("unknown_type(42)");
+        assert_eq!(result, Err(ConfigError::ConfigVariableUnknownType));
+    }
+
+    #[test]
+    fn test_config_store_parse_invalid_value() {
+        let result = ConfigValue::from_str("u32(not_a_number)");
+        assert_eq!(result, Err(ConfigError::ConfigParseValueTypeError));
+    }
+
+    #[test]
     fn test_global_config_store() {
         let store = get_config_store();
 

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -185,6 +185,27 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_config_get() {
+        let result = parse_telecommand("config_get(config_demo_variable1)");
+        assert!(matches!(
+            result,
+            Ok(Telecommand::config_get(ConfigVariableName::ConfigDemoVariable1))
+        ));
+    }
+
+    #[test]
+    fn test_parse_config_set() {
+        let result = parse_telecommand("config_set(config_demo_variable1, u32(8386))");
+        assert!(matches!(
+            result,
+            Ok(Telecommand::config_set(
+                ConfigVariableName::ConfigDemoVariable1,
+                ConfigValue::U32(42)
+            ))
+        ));
+    }
+
+    #[test]
     fn test_placeholder() {
         assert_eq!(42, 42);
     }

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -10,14 +10,14 @@ mod config;
 use config::{ConfigStore, ConfigValue, ConfigVariableName};
 
 pub mod error;
-use error::{ParsedTelecommandErr, ConfigError};
+use error::{ConfigError, ParsedTelecommandErr};
 
 mod shared;
 use shared::extract_function_and_args;
 
+use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
-use core::str::FromStr;
 
 // global static singleton for configuration
 static CONFIG_STORE: ConfigStore = ConfigStore::new();
@@ -83,13 +83,16 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
             let name_str = parts
                 .next()
                 .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
-            let name_enum = ConfigVariableName::from_str(name_str).map_err(|_| {
-                ParsedTelecommandErr::ConfigError(ConfigError::ConfigVariableNotFound)
-            })?;
+            let name_enum = ConfigVariableName::from_str(name_str)
+                .map_err(ParsedTelecommandErr::ConfigError)?;
+
             let value_str = parts
                 .next()
                 .ok_or(ParsedTelecommandErr::MissingArgument(1))?;
-            Ok(Telecommand::config_set())
+            let value_enum =
+                ConfigValue::from_str(value_str).map_err(ParsedTelecommandErr::ConfigError)?;
+
+            Ok(Telecommand::config_set(name_enum, value_enum))
         }
         _ => Err(ParsedTelecommandErr::UnknownCommand),
     }

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -19,13 +19,10 @@ pub enum ConfigVariableName {
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
 pub enum ConfigValue {
     U32(u32),
-    U64(u64),
-    Bool(bool),
-    F32(f32),
-    F64(f64),
-    NullableU32(Option<u32>),
+    // TODO: Add more types as needed (e.g., U64, Bool, F32, F64, etc.)
 }
 
+// Global configuration store
 pub struct ConfigStore {
     heartbeat_ms: AtomicU32,
     config_demo_variable1: AtomicU32,
@@ -33,24 +30,26 @@ pub struct ConfigStore {
 
 impl ConfigStore {
     // create new config store with default values
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             heartbeat_ms: AtomicU32::new(1000),
             config_demo_variable1: AtomicU32::new(0),
         }
     }
 
-    pub fn get(&self, name: ConfigVariableName) -> Option<ConfigValue> {
+    // get a config value by name
+    pub fn get(&self, name: ConfigVariableName) -> ConfigValue {
         match name {
             ConfigVariableName::HeartbeatMs => {
-                Some(ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed)))
+                ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed))
             }
-            ConfigVariableName::ConfigDemoVariable1 => Some(ConfigValue::U32(
-                self.config_demo_variable1.load(Ordering::Relaxed),
-            )),
+            ConfigVariableName::ConfigDemoVariable1 => {
+                ConfigValue::U32(self.config_demo_variable1.load(Ordering::Relaxed))
+            }
         }
     }
 
+    // set a configuration value by name
     pub fn set(&self, name: ConfigVariableName, value: ConfigValue) -> Result<(), ConfigError> {
         match (name, value) {
             (ConfigVariableName::HeartbeatMs, ConfigValue::U32(v)) => {
@@ -66,20 +65,23 @@ impl ConfigStore {
     }
 }
 
+// config operation errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigError {
     TypeMismatch,
 }
 
-static CONFIG_STORE: ConfigStore = ConfigStore::new(); // Global singleton
+// global static singleton for configuration
+static CONFIG_STORE: ConfigStore = ConfigStore::new();
 
+// get reference to the global configuration store
 pub fn get_config_store() -> &'static ConfigStore {
     &CONFIG_STORE
 }
 
-// --- Telecommand Structures ---
-#[derive(Debug)]
-#[allow(non_camel_case_types)] // Allow telecommand names that align with their function names.
+// --- Existing Telecommand Code ---
+#[derive(Debug, Deserialize, Serialize)]
+
 pub struct DemoCommandWithArgumentsArgs {
     pub arg_u32: u32,
     pub arg_u64: u64,
@@ -89,30 +91,14 @@ pub struct DemoCommandWithArgumentsArgs {
     pub arg_nullable_u32: Option<u32>,
 }
 
-pub struct ConfigGetArgs {
-    // required arguments for a config get command
-    pub name: ConfigVariableName,
-}
-
-pub struct ConfigSetArgs {
-    // required arguments for a config set command
-    pub name: ConfigVariableName,
-    pub value: ConfigValue,
-}
-
-pub struct TelecommandExecutionResult {
-    pub success: bool,
-    pub message: &'static str,
-}
+#[derive(Debug)]
+#[allow(non_camel_case_types)]
 
 pub enum Telecommand {
     hello_world,
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
-    config_get(ConfigGetArgs),
-    config_set(ConfigSetArgs),
 }
 
-// --- Telecommand Parsing ---
 // TODO: Replace with meaningful telecommands
 #[allow(clippy::result_unit_err)]
 pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
@@ -132,16 +118,17 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
                     .map_err(|_| ())?;
             Ok(Telecommand::demo_command_with_arguments(args))
         }
-        "config_get" => {
-            let (args, _rest) =
-                from_slice::<ConfigGetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
-            Ok(Telecommand::config_get(args))
-        }
-        "config_set" => {
-            let (args, _rest) =
-                from_slice::<ConfigSetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
-            Ok(Telecommand::config_set(args))
-        }
+        // TODO: Add config_get and config_set telecommands that interact with the ConfigStore
+        // "config_get" => {
+        //     let (args, _rest) =
+        //         from_slice::<ConfigGetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
+        //     Ok(Telecommand::config_get(args))
+        // }
+        // "config_set" => {
+        //     let (args, _rest) =
+        //         from_slice::<ConfigSetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
+        //     Ok(Telecommand::config_set(args))
+        // }
         _ => Err(()),
     }
 }
@@ -149,6 +136,58 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_config_store_get_set() {
+        let store = ConfigStore::new();
+
+        // Test default values
+        assert_eq!(
+            store.get(ConfigVariableName::HeartbeatMs),
+            ConfigValue::U32(1000)
+        );
+        assert_eq!(
+            store.get(ConfigVariableName::ConfigDemoVariable1),
+            ConfigValue::U32(0)
+        );
+
+        // Test setting values
+        assert!(
+            store
+                .set(ConfigVariableName::HeartbeatMs, ConfigValue::U32(2000))
+                .is_ok()
+        );
+        assert_eq!(
+            store.get(ConfigVariableName::HeartbeatMs),
+            ConfigValue::U32(2000)
+        );
+
+        assert!(
+            store
+                .set(
+                    ConfigVariableName::ConfigDemoVariable1,
+                    ConfigValue::U32(42)
+                )
+                .is_ok()
+        );
+        assert_eq!(
+            store.get(ConfigVariableName::ConfigDemoVariable1),
+            ConfigValue::U32(42)
+        );
+    }
+
+    #[test]
+    fn test_global_config_store() {
+        let store = get_config_store();
+
+        store
+            .set(ConfigVariableName::HeartbeatMs, ConfigValue::U32(500))
+            .unwrap();
+        assert_eq!(
+            store.get(ConfigVariableName::HeartbeatMs),
+            ConfigValue::U32(500)
+        );
+    }
 
     #[test]
     fn test_placeholder() {
@@ -200,7 +239,6 @@ mod tests {
 
     #[test]
     fn test_parse_json() {
-        // Note: This is mostly a test of the serde_json_core library functionality.
         let json_data = r#"
         {
             "arg_u32": 123,
@@ -234,7 +272,6 @@ mod tests {
             Ok(Telecommand::demo_command_with_arguments(_))
         ));
 
-        // Validate the parts inside the struct.
         assert!(
             if let Ok(Telecommand::demo_command_with_arguments(args)) = result {
                 args.arg_u32 == 123

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -7,13 +7,14 @@
 extern crate std;
 
 mod config;
-use config::{ConfigStore, ConfigVariableName, ConfigValue};
+use config::{ConfigStore, ConfigValue, ConfigVariableName};
 
 pub mod error;
-use error::ParsedTelecommandErr;
+use error::{ParsedTelecommandErr, ConfigError};
 
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
+use core::str::FromStr;
 
 // global static singleton for configuration
 static CONFIG_STORE: ConfigStore = ConfigStore::new();
@@ -67,9 +68,20 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
             Ok(Telecommand::demo_command_with_arguments(args))
         }
         "get_sys_uptime" => Ok(Telecommand::get_sys_uptime),
-        // "config_get" => {
-        //     Ok(Telecommand::config_get())
-        // }
+        "config_get" => {
+            let mut parts = command_args_str.split(',').map(|s| s.trim());
+            let name_str = parts
+                .next()
+                .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
+            let name_enum = ConfigVariableName::from_str(name_str).map_err(|_| {
+                ParsedTelecommandErr::ConfigError(ConfigError::ConfigVariableNotFound)
+            })?;
+            if parts.next().is_some() {
+                return Err(ParsedTelecommandErr::ExceededArgumentCount);
+            }
+
+            Ok(Telecommand::config_get(name_enum))
+        }
         // "config_set" => {
         //     Ok(Telecommand::config_set())
         // }

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -92,6 +92,10 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
             let value_enum =
                 ConfigValue::from_str(value_str).map_err(ParsedTelecommandErr::ConfigError)?;
 
+            if parts.next().is_some() {
+                return Err(ParsedTelecommandErr::ExceededArgumentCount);
+            }
+
             Ok(Telecommand::config_set(name_enum, value_enum))
         }
         _ => Err(ParsedTelecommandErr::UnknownCommand),

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -5,16 +5,79 @@ extern crate std;
 
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
+use core:: sync:: atomic::{AtomicU32, Ordering};
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct DemoCommandWithArgumentsArgs {
-    pub arg_u32: u32,
-    pub arg_u64: u64,
-    pub arg_bool: bool,
-    pub arg_f32: f32,
-    pub arg_f64: f64,
-    pub arg_nullable_u32: Option<u32>,
+// --- Configuration Store (snake_case for json) ---
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ConfigVariableName {
+    #[serde(rename = "heartbeat_ms")]
+    HeartbeatMs,
+    #[serde(rename = "config_demo_variable1")]
+    ConfigDemoVariable1,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+pub enum ConfigValue {
+    U32(u32),
+    U64(u64),
+    Bool(bool),
+    F32(f32),
+    F64(f64),
+    NullableU32(Option<u32>),
+}
+
+pub struct ConfigStore {
+    heartbeat_ms: AtomicU32,
+    config_demo_variable1: AtomicU32,
+}
+
+impl ConfigStore {
+    // create new config store with default values
+    pub fn new() -> Self {
+        Self {
+            heartbeat_ms: AtomicU32::new(1000),
+            config_demo_variable1: AtomicU32::new(0),
+        }
+    }
+
+    pub fn get(&self, name: ConfigVariableName) -> Option<ConfigValue> {
+        match name {
+            ConfigVariableName::HeartbeatMs => {
+                Some(ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed)))
+            }
+            ConfigVariableName::ConfigDemoVariable1 => {
+                Some(ConfigValue::U32(self.config_demo_variable1.load(Ordering::Relaxed)))
+            }
+        }
+    }
+
+    pub fn set(&self, name: ConfigVariableName, value: ConfigValue) -> Result<(), ConfigError> {
+        match (name, value) {
+            (ConfigVariableName::HeartbeatMs, ConfigValue::U32(v)) => {
+                self.heartbeat_ms.store(v, Ordering::Relaxed);
+                Ok(())
+            }
+            (ConfigVariableName::ConfigDemoVariable1, ConfigValue::U32(v)) => {
+                self.config_demo_variable1.store(v, Ordering::Relaxed);
+                Ok(())
+            }
+            _ => Err(ConfigError::TypeMismatch),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigError {
+    TypeMismatch,
+}
+
+static CONFIG_STORE: ConfigStore = ConfigStore::new(); // Global singleton
+
+pub fn get_config_store() -> &'static ConfigStore {
+    &CONFIG_STORE
+}
+
+// --- Telecommand Structures ---
 
 #[derive(Debug)]
 #[allow(non_camel_case_types)] // Allow telecommand names that align with their function names.

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 extern crate std;
 
-mod config;
+pub mod config;
 use config::{ConfigStore, ConfigValue, ConfigVariableName};
 
 pub mod error;

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate std;
 
 mod config;
-use config::ConfigStore;
+use config::{ConfigStore, ConfigVariableName, ConfigValue};
 
 pub mod error;
 use error::ParsedTelecommandErr;
@@ -42,6 +42,8 @@ pub enum Telecommand {
     hello_world, // telecommand with no args
     get_sys_uptime,
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
+    config_get(ConfigVariableName),
+    config_set(ConfigVariableName, ConfigValue),
 }
 
 // TODO: Replace with meaningful telecommands
@@ -65,6 +67,12 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
             Ok(Telecommand::demo_command_with_arguments(args))
         }
         "get_sys_uptime" => Ok(Telecommand::get_sys_uptime),
+        // "config_get" => {
+        //     Ok(Telecommand::config_get())
+        // }
+        // "config_set" => {
+        //     Ok(Telecommand::config_set())
+        // }
         _ => Err(ParsedTelecommandErr::UnknownCommand),
     }
 }
@@ -72,7 +80,6 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::{ConfigVariableName, ConfigValue};
 
     #[test]
     fn test_config_store_get_set() {

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -189,7 +189,9 @@ mod tests {
         let result = parse_telecommand("config_get(config_demo_variable1)");
         assert!(matches!(
             result,
-            Ok(Telecommand::config_get(ConfigVariableName::ConfigDemoVariable1))
+            Ok(Telecommand::config_get(
+                ConfigVariableName::ConfigDemoVariable1
+            ))
         ));
     }
 

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -1,3 +1,6 @@
+// Use Mutex to safely share peripherals across tasks/interrupt?
+// Implement critical sections for safe access to shared resources?
+
 #![cfg_attr(not(test), no_std)]
 
 #[cfg(test)]
@@ -91,11 +94,13 @@ pub struct DemoCommandWithArgumentsArgs {
     pub arg_nullable_u32: Option<u32>,
 }
 
+// TODO:Add more args for other telecommands as needed
+
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
 
 pub enum Telecommand {
-    hello_world,
+    hello_world, // telecommand with no args
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
 }
 

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -6,73 +6,11 @@
 #[cfg(test)]
 extern crate std;
 
-use core::sync::atomic::{AtomicU32, Ordering};
+mod config;
+use config::ConfigStore;
+
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
-
-// --- Configuration Store (snake_case for json) ---
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-pub enum ConfigVariableName {
-    #[serde(rename = "heartbeat_ms")]
-    HeartbeatMs,
-    #[serde(rename = "config_demo_variable1")]
-    ConfigDemoVariable1,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
-pub enum ConfigValue {
-    U32(u32),
-    // TODO: Add more types as needed (e.g., U64, Bool, F32, F64, etc.)
-}
-
-// Global configuration store
-pub struct ConfigStore {
-    heartbeat_ms: AtomicU32,
-    config_demo_variable1: AtomicU32,
-}
-
-impl ConfigStore {
-    // create new config store with default values
-    pub const fn new() -> Self {
-        Self {
-            heartbeat_ms: AtomicU32::new(1000),
-            config_demo_variable1: AtomicU32::new(0),
-        }
-    }
-
-    // get a config value by name
-    pub fn get(&self, name: ConfigVariableName) -> ConfigValue {
-        match name {
-            ConfigVariableName::HeartbeatMs => {
-                ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed))
-            }
-            ConfigVariableName::ConfigDemoVariable1 => {
-                ConfigValue::U32(self.config_demo_variable1.load(Ordering::Relaxed))
-            }
-        }
-    }
-
-    // set a configuration value by name
-    pub fn set(&self, name: ConfigVariableName, value: ConfigValue) -> Result<(), ConfigError> {
-        match (name, value) {
-            (ConfigVariableName::HeartbeatMs, ConfigValue::U32(v)) => {
-                self.heartbeat_ms.store(v, Ordering::Relaxed);
-                Ok(())
-            }
-            (ConfigVariableName::ConfigDemoVariable1, ConfigValue::U32(v)) => {
-                self.config_demo_variable1.store(v, Ordering::Relaxed);
-                Ok(())
-            }
-            _ => Err(ConfigError::TypeMismatch),
-        }
-    }
-}
-
-// config operation errors
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfigError {
-    TypeMismatch,
-}
 
 // global static singleton for configuration
 static CONFIG_STORE: ConfigStore = ConfigStore::new();
@@ -98,7 +36,6 @@ pub struct DemoCommandWithArgumentsArgs {
 
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
-
 pub enum Telecommand {
     hello_world, // telecommand with no args
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
@@ -141,6 +78,7 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use config::{ConfigVariableName, ConfigValue};
 
     #[test]
     fn test_config_store_get_set() {

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -3,9 +3,9 @@
 #[cfg(test)]
 extern crate std;
 
+use core::sync::atomic::{AtomicU32, Ordering};
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
-use core:: sync:: atomic::{AtomicU32, Ordering};
 
 // --- Configuration Store (snake_case for json) ---
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
@@ -45,9 +45,9 @@ impl ConfigStore {
             ConfigVariableName::HeartbeatMs => {
                 Some(ConfigValue::U32(self.heartbeat_ms.load(Ordering::Relaxed)))
             }
-            ConfigVariableName::ConfigDemoVariable1 => {
-                Some(ConfigValue::U32(self.config_demo_variable1.load(Ordering::Relaxed)))
-            }
+            ConfigVariableName::ConfigDemoVariable1 => Some(ConfigValue::U32(
+                self.config_demo_variable1.load(Ordering::Relaxed),
+            )),
         }
     }
 
@@ -78,21 +78,45 @@ pub fn get_config_store() -> &'static ConfigStore {
 }
 
 // --- Telecommand Structures ---
-
 #[derive(Debug)]
 #[allow(non_camel_case_types)] // Allow telecommand names that align with their function names.
+pub struct DemoCommandWithArgumentsArgs {
+    pub arg_u32: u32,
+    pub arg_u64: u64,
+    pub arg_bool: bool,
+    pub arg_f32: f32,
+    pub arg_f64: f64,
+    pub arg_nullable_u32: Option<u32>,
+}
+
+pub struct ConfigGetArgs {
+    // required arguments for a config get command
+    pub name: ConfigVariableName,
+}
+
+pub struct ConfigSetArgs {
+    // required arguments for a config set command
+    pub name: ConfigVariableName,
+    pub value: ConfigValue,
+}
+
+pub struct TelecommandExecutionResult {
+    pub success: bool,
+    pub message: &'static str,
+}
+
 pub enum Telecommand {
     hello_world,
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
+    config_get(ConfigGetArgs),
+    config_set(ConfigSetArgs),
 }
 
+// --- Telecommand Parsing ---
 // TODO: Replace with meaningful telecommands
-#[allow(clippy::result_unit_err)] // TODO: Fix the () error type to be enum or string
+#[allow(clippy::result_unit_err)]
 pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
-    // Extract string before the first '(' to identify the command.
     let command_name = input.trim().split('(').next().unwrap_or("");
-
-    // Extract arguments string between parentheses, if any.
     let command_args_str = input
         .trim()
         .strip_prefix(command_name)
@@ -100,14 +124,23 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ()> {
         .and_then(|s| s.strip_suffix(')'))
         .unwrap_or("")
         .trim();
-
-    match command_name.trim() {
+    match command_name {
         "hello_world" => Ok(Telecommand::hello_world),
         "demo_command_with_arguments" => {
             let (args, _rest) =
                 from_slice::<DemoCommandWithArgumentsArgs>(command_args_str.as_bytes())
                     .map_err(|_| ())?;
             Ok(Telecommand::demo_command_with_arguments(args))
+        }
+        "config_get" => {
+            let (args, _rest) =
+                from_slice::<ConfigGetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
+            Ok(Telecommand::config_get(args))
+        }
+        "config_set" => {
+            let (args, _rest) =
+                from_slice::<ConfigSetArgs>(command_args_str.as_bytes()).map_err(|_| ())?;
+            Ok(Telecommand::config_set(args))
         }
         _ => Err(()),
     }

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -12,6 +12,9 @@ use config::{ConfigStore, ConfigValue, ConfigVariableName};
 pub mod error;
 use error::{ParsedTelecommandErr, ConfigError};
 
+mod shared;
+use shared::extract_function_and_args;
+
 use serde::{Deserialize, Serialize};
 use serde_json_core::de::from_slice;
 use core::str::FromStr;
@@ -51,14 +54,9 @@ pub enum Telecommand {
 #[allow(clippy::result_unit_err)] // TODO: Fix the () error type to be enum or string
 pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandErr> {
     // Extract string before the first '(' to identify the command.
-    let command_name = input.trim().split('(').next().unwrap_or("");
-    let command_args_str = input
-        .trim()
-        .strip_prefix(command_name)
-        .and_then(|s| s.strip_prefix('('))
-        .and_then(|s| s.strip_suffix(')'))
-        .unwrap_or("")
-        .trim();
+    let (command_name, command_args_str) = extract_function_and_args(input);
+
+    let mut parts = command_args_str.split(',').map(|s| s.trim());
     match command_name {
         "hello_world" => Ok(Telecommand::hello_world),
         "demo_command_with_arguments" => {
@@ -69,7 +67,6 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
         }
         "get_sys_uptime" => Ok(Telecommand::get_sys_uptime),
         "config_get" => {
-            let mut parts = command_args_str.split(',').map(|s| s.trim());
             let name_str = parts
                 .next()
                 .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
@@ -82,9 +79,18 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
 
             Ok(Telecommand::config_get(name_enum))
         }
-        // "config_set" => {
-        //     Ok(Telecommand::config_set())
-        // }
+        "config_set" => {
+            let name_str = parts
+                .next()
+                .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
+            let name_enum = ConfigVariableName::from_str(name_str).map_err(|_| {
+                ParsedTelecommandErr::ConfigError(ConfigError::ConfigVariableNotFound)
+            })?;
+            let value_str = parts
+                .next()
+                .ok_or(ParsedTelecommandErr::MissingArgument(1))?;
+            Ok(Telecommand::config_set())
+        }
         _ => Err(ParsedTelecommandErr::UnknownCommand),
     }
 }

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -46,8 +46,8 @@ pub enum Telecommand {
     hello_world, // telecommand with no args
     get_sys_uptime,
     demo_command_with_arguments(DemoCommandWithArgumentsArgs),
-    config_get(ConfigVariableName),
-    config_set(ConfigVariableName, ConfigValue),
+    get_config(ConfigVariableName),
+    set_config(ConfigVariableName, ConfigValue),
 }
 
 // TODO: Replace with meaningful telecommands
@@ -66,7 +66,7 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
             Ok(Telecommand::demo_command_with_arguments(args))
         }
         "get_sys_uptime" => Ok(Telecommand::get_sys_uptime),
-        "config_get" => {
+        "get_config" => {
             let name_str = parts
                 .next()
                 .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
@@ -77,9 +77,9 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
                 return Err(ParsedTelecommandErr::ExceededArgumentCount);
             }
 
-            Ok(Telecommand::config_get(name_enum))
+            Ok(Telecommand::get_config(name_enum))
         }
-        "config_set" => {
+        "set_config" => {
             let name_str = parts
                 .next()
                 .ok_or(ParsedTelecommandErr::MissingArgument(0))?;
@@ -96,7 +96,7 @@ pub fn parse_telecommand(input: &str) -> Result<Telecommand, ParsedTelecommandEr
                 return Err(ParsedTelecommandErr::ExceededArgumentCount);
             }
 
-            Ok(Telecommand::config_set(name_enum, value_enum))
+            Ok(Telecommand::set_config(name_enum, value_enum))
         }
         _ => Err(ParsedTelecommandErr::UnknownCommand),
     }
@@ -189,22 +189,22 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_config_get() {
-        let result = parse_telecommand("config_get(config_demo_variable1)");
+    fn test_parse_get_config() {
+        let result = parse_telecommand("get_config(config_demo_variable1)");
         assert!(matches!(
             result,
-            Ok(Telecommand::config_get(
+            Ok(Telecommand::get_config(
                 ConfigVariableName::ConfigDemoVariable1
             ))
         ));
     }
 
     #[test]
-    fn test_parse_config_set() {
-        let result = parse_telecommand("config_set(config_demo_variable1, u32(8386))");
+    fn test_parse_set_config() {
+        let result = parse_telecommand("set_config(config_demo_variable1, u32(8386))");
         assert!(matches!(
             result,
-            Ok(Telecommand::config_set(
+            Ok(Telecommand::set_config(
                 ConfigVariableName::ConfigDemoVariable1,
                 ConfigValue::U32(8386)
             ))

--- a/cts2_obc_telecommands/src/lib.rs
+++ b/cts2_obc_telecommands/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
         );
         assert_eq!(
             store.get(ConfigVariableName::ConfigDemoVariable1),
-            ConfigValue::U32(0)
+            ConfigValue::U32(123)
         );
 
         // Test setting values
@@ -200,7 +200,7 @@ mod tests {
             result,
             Ok(Telecommand::config_set(
                 ConfigVariableName::ConfigDemoVariable1,
-                ConfigValue::U32(42)
+                ConfigValue::U32(8386)
             ))
         ));
     }

--- a/cts2_obc_telecommands/src/shared.rs
+++ b/cts2_obc_telecommands/src/shared.rs
@@ -1,0 +1,12 @@
+pub fn extract_function_and_args(input: &str) -> (&str, &str) {
+    let command_name = input.trim().split('(').next().unwrap_or("");
+    let command_args_str = input
+        .trim()
+        .strip_prefix(command_name)
+        .and_then(|s| s.strip_prefix('('))
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or("")
+        .trim();
+
+    (command_name, command_args_str)
+}

--- a/docs/Configuration_Variables.md
+++ b/docs/Configuration_Variables.md
@@ -1,0 +1,21 @@
+# Configuration Variables
+
+The storage supports different types of configuration variables. 
+
+The configuration variables are stored in a ConfigStore struct, which is a singleton that can be accessed from anywhere in the code. 
+
+The ConfigStore struct has a get and set function that allows you to get and set the value of a configuration variable.
+
+## HOW TO ADD A NEW CONFIGURATION VARIABLE:
+1. Add actual variable to ConfigStore struct
+2. Add default value to ConfigStore::new()
+3. Add an enum to ConfigVariableName enum
+4. Add a string version to match in ConfigVariableName::from_str()
+5. Add a match case to ConfigStore::get()
+6. Add a match case to ConfigStore::set()
+
+## Notes:
+- Using set_config in telecommand must specify the correct type for the variable being set. The type of the variable will be determined in the get and set function of the ConfigStore implementation
+- ConfigStore will be storing only Atomic types (bool, u32, u8, ...). If you need to store a type that is not available in Atomic types, you can convert it to bits and store in AtomicU32 or AtomicU64. Or you could use Mutex for more complex types.
+    - For example, if you want to store a f32, you can convert it to u32 using 21.3_f32.to_bits() (21.3 is the example float you wanna store here). You might have to do extra stuff to convert in get and set functions to convert back and forth.
+- String type is not yet thought about and tested but it could be possible with Mutex


### PR DESCRIPTION
Have a storage for configuration variables, be able to store/get/set, telecommands for get and set variables. #29 

You can set existing variables to a new value with SerialTest command and view what the variable is storing. 

How to send command:
- get_config(<variable_name>)
Ex: get_config(config_demo_variable1)
You should get a response "Variable: config_demo_variable1 = 123"

- set_config(<variable_name>, <rust_type>(<value>))
Ex: set_config(config_demo_variable1, u32(8386))
You must specify the exact intended type of the variable (to check the type, view the get function implementation in ConfigStore), you should get a response "Variable: config_demo_variable1 set to 8386"